### PR TITLE
changed create account button to not reload page, hid add-button in login page

### DIFF
--- a/cypress/e2e/initial-tests/ui_tests.cy.js
+++ b/cypress/e2e/initial-tests/ui_tests.cy.js
@@ -19,7 +19,20 @@ describe('basic UI tests', () => {
     // cy.visit('https://example.cypress.io/todo')
     cy.visit('http://127.0.0.1:5500/index.html')
   })
-  it('can register', () => {
+  it('can register successfully', (done) => {
+    // exception handling
+    cy.on('uncaught:exception', (err, runnable) => {
+      done()
+      return false
+    })
+
+    // making sure that the required alert gets thrown 
+    cy.on('window:alert',(t)=>{
+      //assertions
+      expect(t).to.contains('Login successful!');
+   })
+
+    
     const usernameToType = 'username';
     const emailToType = 'user@email.com';
     const passwordToType = 'password';
@@ -34,8 +47,27 @@ describe('basic UI tests', () => {
     cy.get('input[name="login-password"]').type(passwordToType)
 
     cy.get('button#login-button').click();
-    
+  })
+  
+  it("user that DNE can't login", (done) => {
+    // exception handling
+    cy.on('uncaught:exception', (err, runnable) => {
+      done()
+      return false
+    })
 
+    // making sure that the required alert gets thrown 
+    cy.on('window:alert',(t)=>{
+      //assertions
+      expect(t).to.contains('No account found with this email.');
+    })
+    const usernameToType = 'username';
+    const emailToType = 'user@email.com';
+    const passwordToType = 'password';
+    cy.get('input[name="login-username"]').type(usernameToType)
+    cy.get('input[name="login-email"]').type(emailToType)
+    cy.get('input[name="login-password"]').type(passwordToType)
+    cy.get('button#login-button').click();
   })
 
   it('starts with no cards scheduled', () => {
@@ -54,6 +86,7 @@ describe('basic UI tests', () => {
 
   
   it('+ button successfully adds card', () => {
+    login();
     cy.get('#fixed-add-button').click()
 
     cy.get('#scheduled-container > h3')      

--- a/cypress/e2e/initial-tests/ui_tests.cy.js
+++ b/cypress/e2e/initial-tests/ui_tests.cy.js
@@ -19,6 +19,24 @@ describe('basic UI tests', () => {
     // cy.visit('https://example.cypress.io/todo')
     cy.visit('http://127.0.0.1:5500/index.html')
   })
+  it('can register', () => {
+    const usernameToType = 'username';
+    const emailToType = 'user@email.com';
+    const passwordToType = 'password';
+    cy.get('a#create-account').click();
+    cy.get('input[name="register-username"]').type(usernameToType)
+    cy.get('input[name="register-email"]').type(emailToType)
+    cy.get('input[name="register-password"]').type(passwordToType)
+
+    cy.get('button#create-account-button').click();
+    cy.get('input[name="login-username"]').type(usernameToType)
+    cy.get('input[name="login-email"]').type(emailToType)
+    cy.get('input[name="login-password"]').type(passwordToType)
+
+    cy.get('button#login-button').click();
+    
+
+  })
 
   it('starts with no cards scheduled', () => {
     // We use the `cy.get()` command to get all elements that match the selector.

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <div class="container1">
         <div id="login-form">
             <h2>Login to Your Account</h2>
-            <form id-unique="login-form" action="#" method="POST" onsubmit="return login(event)">
+            <form id-unique="login-form" action="#" method="post" onsubmit="return login(event)">
                 <div class="form-group">
                     <label for="register-username">Username:</label>
                     <input type="text" id="login-username" name="login-username" required>
@@ -51,7 +51,7 @@
                 <button type="submit" id="login-button" onclick="login()" >Login</button>
                
             </form>
-            <p>Don't have an account? <a href="#" id = "create-account" onclick="showCreateAccount()">Create one</a></p>
+            <p>Don't have an account? <a href="#" id="create-account" onclick="showCreateAccount()">Create one</a></p>
         </div>
         <div id="create-account-form">
             <h2 >Create an Account</h2>
@@ -68,7 +68,7 @@
                     <label for="register-password">Password:</label>
                     <input type="password" id="register-password" name="register-password" required>
                 </div>
-                <button type="button" id='create-account-button' onclick="register()">Create Account</button>
+                <button type="button" id="create-account-button" onclick="register()">Create Account</button>
             </form>
             <p>Already have an account? <a href="#" onclick="showLoginForm()">Login</a></p>
         </div>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <div class="container1">
         <div id="login-form">
             <h2>Login to Your Account</h2>
-            <form id-unique="login-form" action="#" method="post" onsubmit="return login(event)">
+            <form id-unique="login-form" action="#" method="POST" onsubmit="return login(event)">
                 <div class="form-group">
                     <label for="register-username">Username:</label>
                     <input type="text" id="login-username" name="login-username" required>
@@ -51,7 +51,7 @@
                 <button type="submit" id="login-button" onclick="login()" >Login</button>
                
             </form>
-            <p>Don't have an account? <a href="#" onclick="showCreateAccount()">Create one</a></p>
+            <p>Don't have an account? <a href="#" id = "create-account" onclick="showCreateAccount()">Create one</a></p>
         </div>
         <div id="create-account-form">
             <h2 >Create an Account</h2>
@@ -68,7 +68,7 @@
                     <label for="register-password">Password:</label>
                     <input type="password" id="register-password" name="register-password" required>
                 </div>
-                <button type="submit" onclick="register()">Create Account</button>
+                <button type="button" id='create-account-button' onclick="register()">Create Account</button>
             </form>
             <p>Already have an account? <a href="#" onclick="showLoginForm()">Login</a></p>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
         "@types/jest": "^29.5.12",
         "jsdom": "^24.0.0"
       },
-      "dependencies": {
-        "@types/jest": "^29.5.12",
-        "jsdom": "^24.0.0"
-      },
       "devDependencies": {
         "@babel/core": "^7.20.5",
         "@babel/plugin-transform-modules-commonjs": "^7.19.6",
@@ -44,12 +40,7 @@
       "version": "7.24.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
       "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dependencies": {
-        "@babel/highlight": "^7.24.2",
-        "picocolors": "^1.0.0"
         "@babel/highlight": "^7.24.2",
         "picocolors": "^1.0.0"
       },

--- a/source/scripts/storeinfo.js
+++ b/source/scripts/storeinfo.js
@@ -2,10 +2,10 @@
 function showCreateAccount() {
     document.getElementById('login-form').style.display = 'none';
     document.getElementById('create-account-form').style.display = 'block';
-            
 }
 
 function showLoginForm() {
+    console.log('i got here!');
     document.getElementById('create-account-form').style.display = 'none';
     document.getElementById('login-form').style.display = 'block';
 }
@@ -24,10 +24,11 @@ function register() {
   const userData = { username, email, password };
   localStorage.setItem('user_' + username + email, JSON.stringify(userData));
 
-  alert('Account created successfully!');
+//   alert('Account created successfully!');
   showLoginForm();
 }
 function login(event) {
+
     const email = document.getElementById('login-email').value;
     const password = document.getElementById('login-password').value;
     const username = document.getElementById('login-username').value;


### PR DESCRIPTION
Small fix to address issues that arose 

Quick Fix 1: The create account button was set as a "submit" button, which would reload the page. This broke the website with a "405" error. I changed the type to "button" and that fixed it. From some quick testing, the error showed up on windows pcs, but not macs.

Quick Fix 2:  Hid the "fixed-add-button" from showing up in the login page by setting it to "none" in CSS. This makes it show it starts off hidden, and only un-hides itself after the login is successful.